### PR TITLE
Fixed seeing last activity bug

### DIFF
--- a/frontend/src/css/TripDaysPage.css
+++ b/frontend/src/css/TripDaysPage.css
@@ -13,9 +13,8 @@ body {
   flex: 1;
   overflow-y: auto;
   min-width: 0;
-  padding: 0rem;
   padding: 1rem;
-  padding-bottom: 0rem;
+  padding-bottom: 4rem;
   color: var(--muted);
   height: 100vh;
 }


### PR DESCRIPTION
I added bottom padding to the TripDaysPage so that when you add a lot of activities to a day, you are still able to see the see the last activity fully and it is no longer cut off. 