### PR TITLE
Bug/activity search styling

### DIFF
--- a/frontend/src/css/ActivitySearch.css
+++ b/frontend/src/css/ActivitySearch.css
@@ -168,9 +168,9 @@ body {
   display: grid;
   grid-template-columns: repeat(2, 1fr);
   gap: 12px;
-  flex: 1;
   margin-bottom: 1rem;
   overflow: visible;
+  padding-bottom: 2rem;
 }
 
 .activity-card {


### PR DESCRIPTION
Fix the styling of activity cards so that if a search comes up with 1 or 2 results the card height does not grow to fill the container. Added some padding-bottom to the activity container so that the bottom cards are completely visible.