### PR TITLE
Removed duplicate activity fetching/ Fix Activity Search to work without needing to close

### DIFF
--- a/frontend/src/components/ActivitySearch.jsx
+++ b/frontend/src/components/ActivitySearch.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from "react";
+import React, { useState, useEffect, useRef, useMemo } from "react";
 import axios from "axios";
 import "../css/ActivitySearch.css";
 import "../css/Popup.css";
@@ -42,6 +42,7 @@ export default function ActivitySearch({
     onClose,
     days,
     dayIds = [],
+    allDays = [],
     onActivityAdded,
 }) {
     const [query, setQuery] = useState("");
@@ -59,7 +60,6 @@ export default function ActivitySearch({
     const [formCost, setFormCost] = useState("");
     const [notes, setNotes] = useState("");
     const [distanceInfo, setDistanceInfo] = useState(null);
-    const [dayActivities, setDayActivities] = useState([]);
     const [selectedPlace, setSelectedPlace] = useState(null);
     const [transportMode, setTransportMode] = useState("DRIVE");
     const [distanceLoading, setDistanceLoading] = useState(false);
@@ -94,41 +94,12 @@ export default function ActivitySearch({
     }
   };
 
-useEffect(() => {
-  if (!selectedDay) return;
-
-  const fetchActivities = async () => {
-    try {
-      const res = await axios.post(
-        `${import.meta.env.PROD ? VITE_BACKEND_URL : LOCAL_BACKEND_URL}/activities/read/all`,
-        { dayId: dayIds[selectedDay - 1] },
-        { withCredentials: true }
-      );
-
-      const activities = res.data.activities || [];
-
-      // sort activities by start time
-      const sortedActivities = activities.sort((a, b) => {
-        // convert HH:MM string to minutes
-        const timeToMinutes = (t) => {
-          if (!t) return 0;
-          const [h, m] = t.split(":").map(Number);
-          return h * 60 + m;
-        };
-
-        return timeToMinutes(a.activity_startTime) - timeToMinutes(b.activity_startTime);
-      });
-
-      setDayActivities(sortedActivities);
-    } catch (err) {
-      console.error("Failed to fetch activities:", err);
-    }
-  };
-
-  fetchActivities();
-}, [selectedDay]);
-
-
+  const dayActivities = useMemo(() => {
+    if (!selectedDay || !dayIds.length) return [];
+    const dayId = dayIds[selectedDay - 1];
+    const day = allDays.find(d => d.day_id === dayId);
+    return day?.activities || [];
+  }, [selectedDay, dayIds, allDays]);
 
     const formatType = (type) => {
         if (!type) return "N/A";

--- a/frontend/src/pages/TripDaysPage.jsx
+++ b/frontend/src/pages/TripDaysPage.jsx
@@ -1573,6 +1573,7 @@ export default function TripDaysPage() {
                 ? days.map((d) => d.day_id)
                 : []}
               onActivityAdded={(dayId) => fetchDay(dayId)}
+              allDays={days}
             />
           </div>
         )}


### PR DESCRIPTION
We were fetching and sorting activities in two places:
1.TripDaysPage when loading days
2.ActivitySearch with its own separate API call

This caused a bug where if you added an activity and tried to add another one without closing the drawer, the first activity wouldn't show up in the distance calculation. The drawer was stuck with stale data because it only fetched activities when it first opened or when you switched days.

Now ActivitySearch just gets the activities from its parent component as props instead of fetching them itself.
What Changed:
1.Deleted the useEffect that was fetching activities in ActivitySearch
2.Deleted the dayActivities state
3.Added allDays prop to pass down the days array from parent
4.Used useMemo to grab the right day's activities from the prop

Think of useMemo like a cache. It calculates dayActivities once, then only recalculates when one of its dependencies changes.