### PR TITLE
Bug/negative money and activities

### DIFF
--- a/frontend/src/components/ActivitySearch.jsx
+++ b/frontend/src/components/ActivitySearch.jsx
@@ -620,6 +620,11 @@ export default function ActivitySearch({
                             min="0"
                             placeholder="e.g. 90"
                             value={formDuration}
+                            onKeyDown={(e) => {
+                                if (e.key === '-' || e.key === 'e' || e.key === 'E') {
+                                    e.preventDefault();
+                                }
+                            }}
                             onChange={(e) => {
                                 const val = e.target.value;
                                 if(val == '') setFormDuration('');
@@ -650,6 +655,11 @@ export default function ActivitySearch({
                             step="1"
                             placeholder="e.g. 25"
                             value={formCost}
+                            onKeyDown={(e) => {
+                                if (e.key === '-' || e.key === 'e' || e.key === 'E' || e.key === '.') {
+                                    e.preventDefault();
+                                }
+                            }}
                             onChange={(e) => {
                                 const val = e.target.value;
                                 if(val == '') setFormCost('');

--- a/frontend/src/pages/TripDaysPage.jsx
+++ b/frontend/src/pages/TripDaysPage.jsx
@@ -1467,6 +1467,11 @@ export default function TripDaysPage() {
                   type="number"
                   min = "0"
                   value={editDuration}
+                  onKeyDown={(e) => {
+                    if (e.key === '-' || e.key === 'e' || e.key === 'E') {
+                      e.preventDefault();
+                    }
+                  }}
                   onChange={(e) =>{
                     const val = e.target.value;
                     if(val == '') setEditDuration('');
@@ -1497,6 +1502,11 @@ export default function TripDaysPage() {
                   min = "0"
                   step = "1"
                   value={editCost}
+                  onKeyDown={(e) => {
+                    if (e.key === '-' || e.key === 'e' || e.key === 'E' || e.key === '.') {
+                      e.preventDefault();
+                    }
+                  }}
                   onChange={(e) => {
                     const val = e.target.value;
                     if(val == '') setEditCost('');


### PR DESCRIPTION
Before this fix, users could enter negative duration for an activity and negative money for the estimated budget.


The fix: Prevent the user from being able to type a '-' symbol (negative) at all or the 'e' sign which means raised to the 10th power. The reason why we still need an on change in the input fields is because an user could get around not being able to type by copying and pasting a negative number. 