### PR TITLE
Bug/fixing popup inconsistency

### DIFF
--- a/frontend/src/css/ExplorePage.css
+++ b/frontend/src/css/ExplorePage.css
@@ -190,6 +190,7 @@ html[data-theme="dark"] .pill.active { background: var(--accent); color: var(--b
   display: grid;
   place-items: center;
   cursor: pointer;
+  will-change: opacity;
 }
 .carousel-btn:hover { box-shadow: var(--shadow-2); }
 .carousel-btn:focus-visible { outline: none; box-shadow: 0 0 0 3px var(--accent-soft); }
@@ -492,6 +493,5 @@ html[data-theme="dark"] .carousel-btn:focus-visible { outline: none; box-shadow:
   .carousel-btn {
     width: 40px;
     height: 40px;
-    will-change: opacity;
   }
 }

--- a/frontend/src/css/ExplorePage.css
+++ b/frontend/src/css/ExplorePage.css
@@ -487,3 +487,11 @@ html[data-theme="dark"] .carousel-btn:focus-visible { outline: none; box-shadow:
       padding-bottom: 5.5rem;
     }
 }
+
+@media (max-width: 768px) {
+  .carousel-btn {
+    width: 40px;
+    height: 40px;
+    will-change: opacity;
+  }
+}

--- a/frontend/src/css/NewUserSignUpPage.css
+++ b/frontend/src/css/NewUserSignUpPage.css
@@ -104,7 +104,7 @@ body {
 }
 
 .error-message {
-  color: var(--error);
+  color: tomato;
   font-size: 13px;
   margin-top: 5px;
 }

--- a/frontend/src/css/Popup.css
+++ b/frontend/src/css/Popup.css
@@ -111,6 +111,7 @@ html[data-theme="dark"] .popup-input :is(input, textarea, select):focus {
     display: flex;
     align-items: center;
     gap: 0.25rem;
+    font-size: 1em !important;
 }
 
 .overlap-items {
@@ -120,7 +121,8 @@ html[data-theme="dark"] .popup-input :is(input, textarea, select):focus {
 .popup-input input {
     padding: 10px 12px;
     border: 1px solid var(--border-light);
-    border-radius: 10px;
+    border-radius: var(--radius);
+    background: var(--bg-white);
     font-size: 14px;
 }
 
@@ -210,8 +212,8 @@ html[data-theme="dark"] .popup-input :is(input, textarea, select):focus {
 .popup-input .react-datepicker__input-container input {
     width: 100%;
     padding: 12px;
-    border: 1px solid var(--border-input);
-    border-radius: 8px;
+    border: 1px solid var(--border-light);
+    border-radius: var(--radius) !important;
     font-size: 14px;
     background: var(--bg-white) !important;
     color: var(--text);
@@ -260,14 +262,14 @@ form.was-submitted .react-datepicker-wrapper:has(input[value=""]) .mobile-date-i
     box-shadow: 0 0 0 3px var(--accent-soft);
 }
 
-html[data-theme="dark"] .popup-input-field,
+/* html[data-theme="dark"] .popup-input-field,
 html[data-theme="dark"] .popup-input .date-input,
 html[data-theme="dark"] .popup-input .mobile-date-input,
 html[data-theme="dark"] .popup-input .react-datepicker__input-container input {
     background: var(--bg-hover2) !important;
     color: var(--static-white);
     border-color: var(--border-input);
-}
+} */
 
 html[data-theme="dark"] .popup-input .mobile-date-input.placeholder,
 html[data-theme="dark"] .popup-input-field::placeholder,

--- a/frontend/src/css/TripDaysPage.css
+++ b/frontend/src/css/TripDaysPage.css
@@ -788,16 +788,12 @@ html[data-theme="dark"] .day-menu .trash-icon {
 
 .textarea-notes {
     padding: 12px;
-    border: 1px solid var(--border-input);
-    border-radius: var(--radius);
+    border: 1px solid var(--border-light);
+    border-radius: var(--radius) !important;
     font-size: 14px;
-    background: var(--bg-input);
+    background: var(--bg-white);
     color: var(--text);
     width: 100%;
-}
-
-html[data-theme="dark"] .textarea-notes {
-  background: var(--bg-hover2);
 }
 
 .textarea-notes::placeholder {
@@ -1494,10 +1490,6 @@ html[data-theme="dark"] .time-picker {
     opacity: 0.5;
   }
 
-  .participants-list {
-    min-height: 100px;
-  }
-
   .participants-list p{
     padding-top: 25px;
   }
@@ -2001,10 +1993,10 @@ html[data-theme="dark"] .time-picker {
 
 .trip-name-input, .trip-location-input, .date-input, .clone-popup-input, .popup-input .mobile-date-input {
   padding: 12px;
-  border: 1px solid var(--border-input);
+  border: 1px solid var(--border-light);
   border-radius: var(--radius);
   font-size: 14px;
-  background: var(--bg-input) !important;
+  background: var(--bg-white) !important;
   color: var(--text);
   width: 100%;
 }
@@ -2077,4 +2069,10 @@ button,
 body:has(.popup-screen-overlay) {
   overflow: hidden;
   touch-action: none;
+}
+
+.trip-name-textview , .trip-location-textview , .trip-start-date-textview, .trip-notes-textview{
+  font-size: 14px;
+  margin-bottom: 6px;
+  color: var(--muted)
 }

--- a/frontend/src/css/TripPage.css
+++ b/frontend/src/css/TripPage.css
@@ -204,10 +204,10 @@
 
 .trip-page .modal-content .textarea-notes {
     padding: 12px;
-    border: 1px solid var(--border-input);
+    border: 1px solid var(--border-light);
     border-radius: var(--radius);
     font-size: 14px;
-    background: var(--bg-input);
+    background: var(--bg-white);
     color: var(--text);
     width: 100%;
 }
@@ -317,10 +317,10 @@
 
 .modal-content input {
     padding: 12px;
-    border: 1px solid var(--border-input);
+    border: 1px solid var(--border-light);
     border-radius: var(--radius);
     font-size: 14px;
-    background: var(--bg-input);
+    background: var(--bg-white);
     color: var(--text);
     width: 100%;
 }
@@ -346,11 +346,11 @@
     box-shadow: 0 0 0 3px var(--accent-soft);
 }
 
-html[data-theme="dark"] .modal-content input {
+/* html[data-theme="dark"] .modal-content input {
     background: var(--bg-hover2);
     color: var(--static-white);
     border-color: var(--border-input);
-}
+} */
 
 html[data-theme="dark"] .modal-content input::placeholder {
     color: var(--text-placeholder);
@@ -502,9 +502,9 @@ html[data-theme="dark"] .trip-page :is(
   .react-datepicker__input-container input,
   .date-input
 ) {
-    background: var(--bg-hover2) !important;
+    background: var(--bg-white) !important;
     color: var(--static-white) !important;
-    border: 1px solid var(--border-input) !important;
+    border: 1px solid var(--border-light) !important;
     box-shadow: none !important;
 }
 
@@ -612,10 +612,10 @@ select:focus {
 .mobile-date-input {
     width: 100%;
     padding: 12px;
-    border: 1px solid var(--border-input);
-    border-radius: 4px;
+    border: 1px solid var(--border-light);
+    border-radius: var(--radius);
     font-size: 14px;
-    background: var(--bg-input);
+    background: var(--bg-white) !important;
     cursor: pointer;
     color: var(--text);
     user-select: none;


### PR DESCRIPTION
Unify the css in popups, mute the red to tomato for errors on login page, font size on overlapping activities was way too big, for mobile the arrows would sometimes glitch out on explore page (Hassan provided solution):

Before:
<img width="329" height="730" alt="hi1" src="https://github.com/user-attachments/assets/2558cd7b-6dff-4124-baa7-3719308d8803" />
<img width="329" height="730" alt="h2" src="https://github.com/user-attachments/assets/f54c20d4-cd1f-4af3-9a41-17cff0c67c37" />
<img width="329" height="730" alt="h3" src="https://github.com/user-attachments/assets/0389762f-c5fc-40d8-abc9-1b508052667e" />
<img width="500" height="1000" alt="Screenshot 2025-12-16 at 12 57 30 PM" src="https://github.com/user-attachments/assets/0e655f02-024d-424a-b0af-afd0417cdd4a" />


After:
<img width="329" height="730" alt="Screenshot 2025-12-16 at 1 51 51 PM" src="https://github.com/user-attachments/assets/afb7734f-b6ca-44f5-99da-523bed67de29" />
<img width="346" height="729" alt="Screenshot 2025-12-16 at 1 52 33 PM" src="https://github.com/user-attachments/assets/621777c3-f960-40c7-a4de-18392e90c44c" />
<img width="337" height="740" alt="Screenshot 2025-12-16 at 1 53 04 PM" src="https://github.com/user-attachments/assets/1b0475a0-c2eb-4e2d-9542-d94c34634ab3" />
<img width="1440" height="900" alt="Screenshot 2025-12-16 at 1 04 08 PM" src="https://github.com/user-attachments/assets/827e0142-9fa4-4e0b-997e-baa859a802b6" />

